### PR TITLE
Remove underline from homepage logo link

### DIFF
--- a/style.css
+++ b/style.css
@@ -37,9 +37,13 @@ body {
     color: #ff4c4c;
 }
 
+.logo a {
+    text-decoration: none;
+}
+
 .logo-img {
-  display: none;   
-  width: 40px;     
+  display: none;
+  width: 40px;
   height: auto;
 }
 


### PR DESCRIPTION
## Summary
- remove default underline from the SneakerHub logo link on the homepage

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a579a0f5b08328b1df9094606ab521