### PR TITLE
feat: connect cart checkout to order API

### DIFF
--- a/cart/index.html
+++ b/cart/index.html
@@ -83,8 +83,8 @@ button {
     </table>
     <div id="payment-methods" style="margin-top:20px;">
       <strong>วิธีชำระเงิน:</strong>
-      <label style="margin-left:10px;"><input type="radio" name="payment" value="transfer" checked> โอนเงิน</label>
-      <label style="margin-left:10px;"><input type="radio" name="payment" value="cod"> เก็บเงินปลายทาง</label>
+      <label style="margin-left:10px;"><input type="radio" name="payment" value="BANK_TRANSFER" checked> โอนเงิน</label>
+      <label style="margin-left:10px;"><input type="radio" name="payment" value="COD"> เก็บเงินปลายทาง</label>
     </div>
     <p class="total" id="total">รวมทั้งหมด: 0฿</p>
     <div style="text-align:right; margin-top:10px;">


### PR DESCRIPTION
## Summary
- map cart payment methods to backend names
- send checkout request to `/orders` with JWT token
- restore `product_id` in cart items for compatibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a59a86ea7083288907f7b19177be0c